### PR TITLE
Install svg icon from svgz

### DIFF
--- a/org.kde.kamoso.json
+++ b/org.kde.kamoso.json
@@ -39,6 +39,9 @@
                         "url-template": "https://download.kde.org/stable/release-service/$version/src/kamoso-$version.tar.xz"
                     }
                 }
+            ],
+            "post-install": [
+                "cp -v ${FLATPAK_DEST}/share/icons/hicolor/scalable/apps/kamoso.svgz ${FLATPAK_DEST}/share/icons/hicolor/scalable/apps/kamoso.svg"
             ]
         }
     ]

--- a/org.kde.kamoso.json
+++ b/org.kde.kamoso.json
@@ -30,8 +30,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download.kde.org/stable/release-service/23.08.5/src/kamoso-23.08.5.tar.xz",
-                    "sha256": "84cc4538da2906c1503de97e6fb6f1ef790f0e7b9f3c08f6367770e5bdf08d01",
+                    "url": "https://download.kde.org/stable/release-service/24.02.1/src/kamoso-24.02.1.tar.xz",
+                    "sha256": "af7f221f854ccccafcf0bda889d7f7234fa3deb6504d9cd0a140052461977829",
                     "x-checker-data": {
                         "type": "anitya",
                         "project-id": 8763,


### PR DESCRIPTION
The svgz file here is actually not a compressed svg but a plain svg file
with the wrong extension

`flatpak run --command=cat org.kde.kamoso /app/share/icons/hicolor/scalable/apps/org.kde.kamoso.svgz`